### PR TITLE
[TASK] Apply TYPO3 constraint to cms-core instead of minimal

### DIFF
--- a/.ddev/commands/host/reset
+++ b/.ddev/commands/host/reset
@@ -40,7 +40,7 @@ reconfigure_project () {
     fi
 
     ddev config --composer-version ${COMPOSER_VERSION} --mariadb-version ${MARIADB_VERSION} --php-version ${PHP_VERSION} --project-type typo3
-    ddev composer require typo3/minimal:"${TYPO3_VERSION}" typo3/cms-introduction:"${INTRODUCTION_VERSION}" --no-update
+    ddev composer require typo3/cms-core:"${TYPO3_VERSION}" typo3/cms-introduction:"${INTRODUCTION_VERSION}" --no-update
     reset_project
     ddev start
 }

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -18,8 +18,8 @@ use_dns_when_possible: true
 composer_version: "2"
 
 
-# This config.yaml was created with ddev version v1.16.2
-# webimage: drud/ddev-webserver:v1.16.2
+# This config.yaml was created with ddev version v1.16.5
+# webimage: drud/ddev-webserver:v1.16.3
 # dbimage: drud/ddev-dbserver-mariadb-10.2:v1.16.0
 # dbaimage: phpmyadmin:5
 # However we do not recommend explicitly wiring these images into the

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 		"typo3/cms-about": "*",
 		"typo3/cms-belog": "*",
 		"typo3/cms-beuser": "*",
+		"typo3/cms-core": "~10.4.0",
 		"typo3/cms-dashboard": "*",
 		"typo3/cms-filelist": "*",
 		"typo3/cms-info": "*",
@@ -34,7 +35,7 @@
 		"typo3/cms-t3editor": "*",
 		"typo3/cms-tstemplate": "*",
 		"typo3/cms-viewpage": "*",
-		"typo3/minimal": "~10.4.0"
+		"typo3/minimal": "*"
 	},
 	"require-dev": {
 		"symfony/thanks": "^1.2",


### PR DESCRIPTION
Using the constraint for typo3/cms-core instead of typo3/minimal
allows exact pinning of a core version.